### PR TITLE
Add a recursive bloom filter tree.

### DIFF
--- a/src/batching.rs
+++ b/src/batching.rs
@@ -1,5 +1,10 @@
 pub fn batch_items_by_cpu_count<TItem: Clone>(items: &[TItem]) -> Vec<Vec<TItem>> {
     let batch_count = num_cpus::get();
+    
+    batch_items(items, batch_count)
+}
+
+pub fn batch_items<TItem: Clone>(items: &[TItem], batch_count: usize) -> Vec<Vec<TItem>> {
     let items_per_batch = (items.len() as f32 / batch_count as f32).ceil() as usize;
 
     let mut batches = Vec::new(); 

--- a/src/bloom.rs
+++ b/src/bloom.rs
@@ -23,6 +23,18 @@ impl BloomFilter {
         }
     }
 
+    pub fn from_filters(bloom_filters: &[BloomFilter]) -> BloomFilter {
+        let mut combined = bloom_filters.get(0).unwrap().clone();
+
+        for filter in bloom_filters {
+            for (i, item) in filter.filter_array.iter().enumerate() {
+                combined.filter_array[i] |= item;
+            }
+        }
+
+        combined
+    }
+
     pub fn possibly_contains(&self, other: &BloomFilter) -> bool {
         if self.filter_array.len() != other.filter_array.len() {
             panic!("Bloom filters must be the same length to compare.")

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,6 @@
 pub mod index;
 mod bloom;
 mod compression_utils;
-mod parallel;
+mod batching;
 pub mod text_scraping;
 mod trigram;

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,5 +1,5 @@
 use colored::{ColoredString, Colorize};
-use rust_indexer::{index::Index, text_scraping::{self}};
+use rust_indexer::{index::{Index, IndexTree}, text_scraping::{self}};
 use std::env::args;
 
 #[tokio_macros::main]
@@ -32,30 +32,25 @@ async fn main() {
 
         let query = cmd_args.get(3).unwrap();
         let index = Index::from_file(&index_path);
+        let index_tree = IndexTree::from_index(&index);
 
-        let matching_files = get_matching_files(&index, &query).await;
+        let (matching_files, comparisons) = get_matching_files(&index_tree, &query).await;
 
         scrape_and_format_matches(&matching_files, &query).await;
 
-        let files_matched_percentage = (matching_files.len() as f32 / index.files_count() as f32) * 100f32;
-        println!(
-            "Matched {} files ({}%)",
-            matching_files.len(),
-            files_matched_percentage);
+        print_perf_stats(&matching_files, &index, comparisons);
+
     } else if command == "repl" {
         let index = Index::from_file(&index_path);
+        let index_tree = IndexTree::from_index(&index);
 
         loop {
             let query = prompt_for_input("Search >");    
-            let matching_files = get_matching_files(&index, &query).await;
+            let (matching_files, comparisons) = get_matching_files(&index_tree, &query).await;
     
             scrape_and_format_matches(&matching_files, &query).await;
     
-            let files_matched_percentage = (matching_files.len() as f32 / index.files_count() as f32) * 100f32;
-            println!(
-                "Matched {} files ({}%)",
-                matching_files.len(),
-                files_matched_percentage);
+            print_perf_stats(&matching_files, &index, comparisons);
         }
     } else {
         print_help();
@@ -80,12 +75,12 @@ fn prompt_for_input(prompt: &str) -> String {
     buffer
 }
 
-async fn get_matching_files(index: &Index, query: &str) -> Vec<String> {
-    let matches = index.search_files(&query.trim()).await;
-    let mut ordered_matches: Vec<String> = Vec::from_iter(matches);
+async fn get_matching_files(index: &IndexTree, query: &str) -> (Vec<String>, usize) {
+    let matches = index.search_files(&query.trim());
+    let mut ordered_matches: Vec<String> = Vec::from_iter(matches.0);
     ordered_matches.sort();
 
-    ordered_matches
+    (ordered_matches, matches.1)
 }
 
 async fn scrape_and_format_matches(files: &Vec<String>, query: &str) {
@@ -96,6 +91,24 @@ async fn scrape_and_format_matches(files: &Vec<String>, query: &str) {
         println!("{}", scraped_match.text.italic().yellow());
         println!();
     }
+}
+
+fn print_perf_stats(matching_files: &Vec<String>, index: &Index, comparisons: usize) {
+    let files_matched_percentage = (matching_files.len() as f32 / index.files_count() as f32) * 100f32;
+
+    // Percentage of file bloom filters checked. Not technically accurate because this a count
+    // of total bloom comparisons, including non-leaf tree nodes from IndexTree, but it helps
+    // us see the relative cost savings of using IndexTree during lookup to reduce the number
+    // of required bloom comparisons.
+    let bloom_comparisons_percentage = (comparisons as f32 / index.files_count() as f32) * 100f32;
+
+    println!(
+        "Narrowed search to {} of {} files ({}%) using {} bloom comparisons ({}%)",
+        matching_files.len(),
+        index.files_count(),
+        files_matched_percentage,
+        comparisons,
+        bloom_comparisons_percentage);
 }
 
 fn print_with_color(colored_str: ColoredString) {

--- a/src/text_scraping.rs
+++ b/src/text_scraping.rs
@@ -2,7 +2,7 @@ use std::str::FromStr;
 
 use tokio::task::JoinSet;
 
-use crate::parallel::batch_items_by_cpu_count;
+use crate::batching::batch_items_by_cpu_count;
 
 #[derive(Clone)]
 pub struct Match {


### PR DESCRIPTION
Using bloom filter-based search in very large codebases in the target scenario (1 million+ files) ends up being exceptionally slow because we still end up doing O(n) bloom filter comparisons.

This PR introduces IndexTree, a recursive tree of Bloom filters across the set of searchable files. Using this, the runtime starts to resemble log time, albeit somewhat worse due to the probabilistic nature and increasing false positives of the bloom filters in the higher nodes.